### PR TITLE
Add dusk vars to session

### DIFF
--- a/src/Traits/HandlesCheckout.php
+++ b/src/Traits/HandlesCheckout.php
@@ -183,6 +183,10 @@ trait HandlesCheckout
         Validator::make(Request::get('checkout')['shippingMethod'], [
             'id' => 'required|integer|min:1',
         ])->validate();
+
+        if (App::environment(['local', 'staging', 'testing'])) {
+            Session::put('dusk_vars', ['finalTotal' => floatval($this->getFirst('finalTotal'))]);
+        }
     }
 
     /**


### PR DESCRIPTION
Used with custom assertion to determine if checkout is calculating totals correctly.

Same code required for Skinflint.