### PR TITLE
Improved 'Terms & Conditions' link in checkout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.0] - 2018-04-25
+
+### Changed
+
+- Removed hard-coded path to 'Terms & Conditions' page in checkout and replaced with the `route` helper function.
+- Ensured text inside 'Terms & Conditions' link in checkout is translatable.
+- Added class to 'Terms & Conditions' link in checkout in order to style element more easily.
+- Improved readability of 'Terms & Conditions' link markup in checkout.
+
 ## [1.3.2] - 2018-04-24
 
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [1.4.0] - 2018-04-25
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "maxfactor-laravel-checkout",
-    "version": "1.2.3",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maxfactor-laravel-checkout",
-    "version": "1.2.3",
+    "version": "1.4.0",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/src/resources/views/checkout/payment.blade.php
+++ b/src/resources/views/checkout/payment.blade.php
@@ -44,7 +44,7 @@
                         </template>
                     </div>
                     <div class="checkout__terms">
-                        <label><input type="checkbox" v-model="currentCheckout.user.terms">@lang('Please check the box to agree to our') <a href="{{ route('termsConditions') }}" target="_blank">terms &amp; conditions</a></label>
+                        <label><input type="checkbox" v-model="currentCheckout.user.terms">@lang('Please check the box to agree to our') <a href="{{ route('termsConditions') }}" target="_blank">@lang('terms &amp; conditions')</a></label>
                         <v-form-error field="checkout.user.terms"></v-form-error>
                     </div>
 

--- a/src/resources/views/checkout/payment.blade.php
+++ b/src/resources/views/checkout/payment.blade.php
@@ -44,7 +44,7 @@
                         </template>
                     </div>
                     <div class="checkout__terms">
-                        <label><input type="checkbox" v-model="currentCheckout.user.terms">@lang('Please check the box to agree to our') <a href="{{ route('termsConditions') }}" target="_blank">@lang('terms &amp; conditions')</a></label>
+                        <label><input type="checkbox" v-model="currentCheckout.user.terms">@lang('Please check the box to agree to our') <a class="checkout__terms-link" href="{{ route('termsConditions') }}" target="_blank">@lang('terms &amp; conditions')</a></label>
                         <v-form-error field="checkout.user.terms"></v-form-error>
                     </div>
 

--- a/src/resources/views/checkout/payment.blade.php
+++ b/src/resources/views/checkout/payment.blade.php
@@ -44,7 +44,7 @@
                         </template>
                     </div>
                     <div class="checkout__terms">
-                        <label><input type="checkbox" v-model="currentCheckout.user.terms">@lang('Please check the box to agree to our') <a href="/pages/legal/terms-conditions-summary" target="_blank">terms &amp; conditions</a></label>
+                        <label><input type="checkbox" v-model="currentCheckout.user.terms">@lang('Please check the box to agree to our') <a href="{{ route('termsConditions') }}" target="_blank">terms &amp; conditions</a></label>
                         <v-form-error field="checkout.user.terms"></v-form-error>
                     </div>
 

--- a/src/resources/views/checkout/payment.blade.php
+++ b/src/resources/views/checkout/payment.blade.php
@@ -44,7 +44,13 @@
                         </template>
                     </div>
                     <div class="checkout__terms">
-                        <label><input type="checkbox" v-model="currentCheckout.user.terms">@lang('Please check the box to agree to our') <a class="checkout__terms-link" href="{{ route('termsConditions') }}" target="_blank">@lang('terms &amp; conditions')</a></label>
+                        <label>
+                            <input type="checkbox" v-model="currentCheckout.user.terms">
+                            @lang('Please check the box to agree to our')
+                            <a class="checkout__terms-link" href="{{ route('termsConditions') }}" target="_blank">
+                                @lang('terms &amp; conditions')
+                            </a>
+                        </label>
                         <v-form-error field="checkout.user.terms"></v-form-error>
                     </div>
 


### PR DESCRIPTION
### Changed

- Removed hard-coded path to 'Terms & Conditions' page in checkout and replaced with the `route` helper function.
- Ensured text inside 'Terms & Conditions' link in checkout is translatable.
- Added class to 'Terms & Conditions' link in checkout in order to style element more easily.
- Improved readability of 'Terms & Conditions' link markup in checkout.