### PR TITLE
Avoid duplicate payments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2018-08-13
+
+### Changed
+
+- Avoid processing payments on orders which have already been paid
+
 ## [1.5.4] - 2018-07-23
 
 ### Fixed

--- a/src/Contracts/Checkout.php
+++ b/src/Contracts/Checkout.php
@@ -8,4 +8,11 @@ interface Checkout
      * Within the construct, the `content` attribute must be populated with the data from the
      * checkout store / handler. (e.g. remote api or local class)
      */
+
+    /**
+     * Must return true or false depending on whether payment should be taken
+     *
+     * @return boolean
+     */
+    public function isPaymentRequired();
 }

--- a/src/Traits/HandlesCheckout.php
+++ b/src/Traits/HandlesCheckout.php
@@ -5,9 +5,9 @@ namespace Maxfactor\Checkout\Traits;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
-use Maxfactor\Checkout\Handlers\Paypal;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
+use Maxfactor\Checkout\Handlers\Paypal;
 use Illuminate\Support\Facades\Validator;
 use Maxfactor\Checkout\Contracts\Postage;
 use Maxfactor\Checkout\Contracts\Checkout;
@@ -205,6 +205,15 @@ trait HandlesCheckout
 
         // Call relevant validation form request based on $provider
         App::make(sprintf("\Maxfactor\Checkout\Requests\%sPaymentRequest", ucfirst($provider)));
+
+        $checkout = App::make(Checkout::class, [
+            'uid' => $this->getFirst('uid'),
+        ]);
+
+        if (!$checkout->isPaymentRequired()) {
+            // This order has already been paid
+            return $this;
+        }
 
         // Pass to payment handler for processing payment
         $paymentResponseData = (new PaymentWrapper($provider))


### PR DESCRIPTION
Is a somewhat breaking change as the Checkout contract has a new method which is required by its implementation. This allows the package to gain some knowledge about the `Order` to determined if it has already been paid.