### PR TITLE
PayPal Auth Issue

### DIFF
--- a/src/Traits/HandlesCheckout.php
+++ b/src/Traits/HandlesCheckout.php
@@ -275,9 +275,9 @@ trait HandlesCheckout
     public function checkoutStageShowPaypalauth()
     {
         $this->syncSession();
-        
+
         $paypal = (new Paypal());
-        
+
         $response = $paypal->authorize([
             'amount' => $paypal->formatAmount($this->getFirst('finalTotal')),
             'transactionId' => $this->getFirst('orderID'),


### PR DESCRIPTION
I'm not sure of the best course of action here, the changes in this PR are mainly to log errors which are happening within the PayPal authorisation. Let me explain.

The error which is seen repeatedly in Sentry is due to the use of the `show` method in the `CheckoutController`.  When a user is successfully redirected to the offsite PayPal express authorisation, the FFT site tries to render a view for the checkout stage, which is `paypalauth`.  This isn't seen by the user but obviously we need to address it properly.  The `exit()` I've added stops us trying to render the view, but doesn't feel like a great solution.

I have also added logging for errors in the event that the PayPal authorisation fails, and return the user to the `/cart` page.  