### PR TITLE
PayPal address after authorization (again)

### DIFF
--- a/src/resources/assets/js/Checkout/Components/AddressLookup.vue
+++ b/src/resources/assets/js/Checkout/Components/AddressLookup.vue
@@ -169,7 +169,7 @@
             /**
              * Show the full address if we are returning from paypal
              */
-            if (this.activeCartCollection.payment.provider) this.ui.showAddress = true
+            if (this.activeCartCollection.payment.provider === 'paypal') this.ui.showAddress = true
         },
 
     }


### PR DESCRIPTION
This one goes out to our good friends Automated Testing.

Turns out on a standard checkout flow the `payment.provider` is set, so the code how I had it failed to show the address lookup.

Now explicitly checking for PayPal as the provider.