### PR TITLE
Minimum order value redirect

### DIFF
--- a/src/Traits/HandlesCheckout.php
+++ b/src/Traits/HandlesCheckout.php
@@ -70,7 +70,9 @@ trait HandlesCheckout
             && $mode === 'show'
             && $this->getFirst('finalTotal') < config('maxfactor-checkout.minimum_order')) {
             Session::put('checkoutError', 'Order value error');
+            Session::save();
             header('Location: ' . route('cart.index'));
+            exit();
         }
         
         $uid = $this->uid = Route::current()->parameter('uid');


### PR DESCRIPTION
Need to call exit() for the redirect to work in production environments

This was breaking the Session::put() functionality

Discovered that Session::save() ensures the new session value is persisted