### PR TITLE
Order min value with discount code

### DIFF
--- a/src/Traits/HandlesCheckout.php
+++ b/src/Traits/HandlesCheckout.php
@@ -94,7 +94,7 @@ trait HandlesCheckout
          */
         if ($stage !== 'default'
             && $mode === 'show'
-            && $this->getFirst('finalTotal') < config('maxfactor-checkout.minimum_order')) {
+            && $this->getFirst('finalTotalExcDiscount') < config('maxfactor-checkout.minimum_order')) {
             Session::put('checkoutError', 'Order value error');
             Session::save();
             header('Location: ' . route('cart.index'));
@@ -219,7 +219,7 @@ trait HandlesCheckout
         /**
          * Do not proceed if order has dropped below min value
          */
-        if ($this->getFirst('finalTotal') < config('maxfactor-checkout.minimum_order')) {
+        if ($this->getFirst('finalTotalExcDiscount') < config('maxfactor-checkout.minimum_order')) {
             return $this;
         }
 


### PR DESCRIPTION
Use checkout order total before discount when determining if order meets min value.

This means that if an order drops below the minimum value using a discount code, it should still be processed.

This is a customer decision and potentially needs to be configurable in the future, premature complications at this stage though I feel.